### PR TITLE
Use Ractor.shareable_proc

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -233,7 +233,10 @@ class OpenStruct
   #
   def new_ostruct_member!(name) # :nodoc:
     unless @table.key?(name) || is_method_protected!(name)
-      if defined?(::Ractor)
+      if defined?(::Ractor.shareable_proc)
+        getter_proc = Ractor.shareable_proc { @table[name] }
+        setter_proc = Ractor.shareable_proc {|x| @table[name] = x}
+      else if defined?(::Ractor)
         getter_proc = nil.instance_eval{ Proc.new { @table[name] } }
         setter_proc = nil.instance_eval{ Proc.new {|x| @table[name] = x} }
         ::Ractor.make_shareable(getter_proc)


### PR DESCRIPTION
We will introduce `Ractor.shareable_proc` and prohibit `Ractor.make_shareable(a_proc)` soon.